### PR TITLE
Remove superfluous deps

### DIFF
--- a/tools/binding-generator/package.json
+++ b/tools/binding-generator/package.json
@@ -10,8 +10,6 @@
   "author": "Jonathan Siebern <jsiebern88@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@jsiebern/json-schema-parser": "^0.0.11",
-    "@jsiebern/mui-component-extractor": "1.0.0",
     "@material-ui/core": "4.11.4",
     "bs-platform": "^9.0.2",
     "lodash": "~4.17.11",


### PR DESCRIPTION
It seems these are not required, as the packages are in the monorepo/workspace anyway.
build.sh runs successfully without these.