### PR TITLE
docs: update link to examples folder

### DIFF
--- a/documentation/docs/examples.md
+++ b/documentation/docs/examples.md
@@ -3,7 +3,7 @@ title: Examples
 ---
 
 See the
-[examples folder](https://github.com/cca-io/rescript-material-ui/tree/master/public/rescript-material-ui/examples)
+[examples folder](https://github.com/cca-io/rescript-material-ui/tree/rescript-material-ui/examples)
 for more information.
 
 ## Installing and trying the examples

--- a/documentation/docs/examples.md
+++ b/documentation/docs/examples.md
@@ -3,7 +3,7 @@ title: Examples
 ---
 
 See the
-[examples folder](https://github.com/cca-io/rescript-material-ui/tree/rescript-material-ui/examples)
+[examples folder](https://github.com/cca-io/rescript-material-ui/tree/master/examples)
 for more information.
 
 ## Installing and trying the examples


### PR DESCRIPTION
Currently, the link to the examples folder 404s. This updates with a working link to the examples folder.

Closes #157