### PR TITLE
Children react element

### DIFF
--- a/examples/src/examples/ExampleDashboard.res
+++ b/examples/src/examples/ExampleDashboard.res
@@ -174,7 +174,7 @@ let make = (~sidebar, ~children) => {
                     setShow(false)
                   }}
                   color=#secondary>
-                  "Close Dashboard"
+                  {"Close Dashboard"->React.string}
                 </Link>
                 <IconButton color=#inherit>
                   <Badge badgeContent={"4"->React.string} color=#secondary>
@@ -205,7 +205,7 @@ let make = (~sidebar, ~children) => {
           </div>
         </div>
       : <MaterialUi.Button variant=#outlined color=#primary onClick={_ => setShow(true)}>
-          "Open Dashboard"
+          {"Open Dashboard"->React.string}
         </MaterialUi.Button>}
   </div>
 }

--- a/examples/src/examples/ExamplePopover.res
+++ b/examples/src/examples/ExamplePopover.res
@@ -40,7 +40,8 @@ let make = () => {
       </div>
     </Popover>
     <MaterialUi.List>
-      {messages->Belt.Array.mapWithIndex((i, message) =>
+      {messages
+      ->Belt.Array.mapWithIndex((i, message) =>
         <ListItem
           button=true
           key={string_of_int(i)}
@@ -48,7 +49,8 @@ let make = () => {
             dispatch(OpenPopup((evt->ReactEvent.Mouse.target->toDomElement, message)))}>
           <ListItemText> {React.string(message)} </ListItemText>
         </ListItem>
-      )}
+      )
+      ->React.array}
     </MaterialUi.List>
   </div>
 }

--- a/examples/src/examples/ExampleSelect.res
+++ b/examples/src/examples/ExampleSelect.res
@@ -97,7 +97,7 @@ let make = () => {
         <FormHelperText> {"Label + placeholder"->React.string} </FormHelperText>
       </FormControl>
       <FormControl className={classes["formControl"]} disabled=true>
-        <InputLabel htmlFor="name-disabled"> "Name" </InputLabel>
+        <InputLabel htmlFor="name-disabled"> {"Name"->React.string} </InputLabel>
         <Select
           value={Select.Value.string(values.name)}
           onChange=handleChangeName
@@ -110,7 +110,7 @@ let make = () => {
         <FormHelperText> {"Disabled"->React.string} </FormHelperText>
       </FormControl>
       <FormControl className={classes["formControl"]} error=true>
-        <InputLabel htmlFor="name-error"> "Name" </InputLabel>
+        <InputLabel htmlFor="name-error"> {"Name"->React.string} </InputLabel>
         <Select
           value={Select.Value.string(values.name)}
           onChange=handleChangeName
@@ -125,7 +125,7 @@ let make = () => {
         <FormHelperText> {"Error"->React.string} </FormHelperText>
       </FormControl>
       <FormControl className={classes["formControl"]}>
-        <InputLabel htmlFor="name-readonly"> "Name" </InputLabel>
+        <InputLabel htmlFor="name-readonly"> {"Name"->React.string} </InputLabel>
         <Select
           value={Select.Value.string(values.name)}
           onChange=handleChangeName
@@ -158,7 +158,9 @@ let make = () => {
           name="age"
           displayEmpty=true
           className={classes["selectEmpty"]}>
-          <MenuItem value={MenuItem.Value.string("")} disabled=true> "Placeholder" </MenuItem>
+          <MenuItem value={MenuItem.Value.string("")} disabled=true>
+            {"Placeholder"->React.string}
+          </MenuItem>
           <MenuItem value={MenuItem.Value.string("10")}> {"Ten"->React.string} </MenuItem>
           <MenuItem value={MenuItem.Value.string("20")}> {"Twenty"->React.string} </MenuItem>
           <MenuItem value={MenuItem.Value.string("30")}> {"Thirty"->React.string} </MenuItem>

--- a/examples/src/examples/ExampleServerStyleSheets.res
+++ b/examples/src/examples/ExampleServerStyleSheets.res
@@ -21,7 +21,7 @@ let make = () => {
   })
 
   <div>
-    <Typography variant=#h5> "ServerSide render of <ExampleBox />" </Typography>
+    <Typography variant=#h5> {"ServerSide render of <ExampleBox />"->React.string} </Typography>
     <TextField
       className={classes["code"]}
       rows={TextField.Rows.int(5)}

--- a/examples/src/examples/ExampleSlider.res
+++ b/examples/src/examples/ExampleSlider.res
@@ -16,7 +16,7 @@ let make = () => {
   let (value, setValue) = React.useReducer((_, v) => v, 0)
 
   <div className={classes["root"]}>
-    <Typography gutterBottom=true> "Volume" </Typography>
+    <Typography gutterBottom=true> {"Volume"->React.string} </Typography>
     <Grid container=true spacing=#2 alignItems=#center>
       <Grid item=true> <VolumeUpIcon /> </Grid>
       <Grid item=true xs=Grid.Xs.\"true">

--- a/examples/src/examples/ExampleStepper.res
+++ b/examples/src/examples/ExampleStepper.res
@@ -49,7 +49,8 @@ let make = () => {
 
   <div className={classes["root"]}>
     <Stepper activeStep={Number.int(activeStep)} orientation=#vertical>
-      {steps->Belt.Array.mapWithIndex((index, label) =>
+      {steps
+      ->Belt.Array.mapWithIndex((index, label) =>
         <Step key=label>
           <StepLabel> {label->React.string} </StepLabel>
           <StepContent>
@@ -71,7 +72,8 @@ let make = () => {
             </div>
           </StepContent>
         </Step>
-      )}
+      )
+      ->React.array}
     </Stepper>
     {activeStep === steps->Belt.Array.length
       ? <Paper square=true elevation={Number.int(0)} className={classes["resetContainer"]}>

--- a/examples/src/examples/Examples.res
+++ b/examples/src/examples/Examples.res
@@ -4,7 +4,7 @@ open MaterialUi
 let make = () => <>
   <Grid container=true>
     <Grid item=true md=Grid.Md.\"12">
-      <Typography variant=#h4> "ReScript Material-UI Examples" </Typography>
+      <Typography variant=#h4> {"ReScript Material-UI Examples"->React.string} </Typography>
     </Grid>
   </Grid>
   <br />
@@ -13,7 +13,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Class Override" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Class Override"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleClassOverride /> </Grid>
   </Grid>
   <br />
@@ -22,7 +24,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Icons" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Icons"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleIcons /> </Grid>
   </Grid>
   <br />
@@ -31,7 +35,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Popover" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Popover"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExamplePopover /> </Grid>
   </Grid>
   <br />
@@ -40,7 +46,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Styles" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Styles"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleStyles /> </Grid>
   </Grid>
   <br />
@@ -49,7 +57,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Theme Provider" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Theme Provider"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleThemeProvider /> </Grid>
   </Grid>
   <br />
@@ -59,7 +69,7 @@ let make = () => <>
   <br />
   <Grid container=true alignItems=#center>
     <Grid item=true md=Grid.Md.\"6">
-      <Typography variant=#h5> "Theme Provider Override" </Typography>
+      <Typography variant=#h5> {"Theme Provider Override"->React.string} </Typography>
     </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleThemeProviderOverride /> </Grid>
   </Grid>
@@ -69,7 +79,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "List" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"List"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleList /> </Grid>
   </Grid>
   <br />

--- a/examples/src/labExamples/ExampleRating.res
+++ b/examples/src/labExamples/ExampleRating.res
@@ -9,7 +9,9 @@ let make = () => {
       component={Box.Component.string("fieldset")}
       mb={Box.Value.int(3)}
       borderColor={Box.Value.string("transparent")}>
-      <Typography component={Typography.Component.string("legend")}> "Controlled" </Typography>
+      <Typography component={Typography.Component.string("legend")}>
+        {"Controlled"->React.string}
+      </Typography>
       <Rating
         name="simple-controlled"
         value={Number.int(value)}
@@ -20,14 +22,18 @@ let make = () => {
       component={Box.Component.string("fieldset")}
       mb={Box.Value.int(3)}
       borderColor={Box.Value.string("transparent")}>
-      <Typography component={Typography.Component.string("legend")}> "Read only" </Typography>
+      <Typography component={Typography.Component.string("legend")}>
+        {"Read only"->React.string}
+      </Typography>
       <Rating name="read-only" value={Number.int(value)} readOnly=true />
     </Box>
     <Box
       component={Box.Component.string("fieldset")}
       mb={Box.Value.int(3)}
       borderColor={Box.Value.string("transparent")}>
-      <Typography component={Typography.Component.string("legend")}> "Disabled" </Typography>
+      <Typography component={Typography.Component.string("legend")}>
+        {"Disabled"->React.string}
+      </Typography>
       <Rating name="disabled" value={Number.int(value)} disabled=true />
     </Box>
     <Box

--- a/examples/src/labExamples/ExampleToggleButton.res
+++ b/examples/src/labExamples/ExampleToggleButton.res
@@ -63,7 +63,7 @@ let make = () => {
           </ToggleButton>
         </ToggleButtonGroup>
       </Box>
-      <Typography gutterBottom=true> "Exclusive Selection" </Typography>
+      <Typography gutterBottom=true> {"Exclusive Selection"->React.string} </Typography>
       <Typography>
         {`Text justification toggle buttons present options for left, right, center, full, and
       justified text with only one item available for selection at a time. Selecting one option
@@ -83,10 +83,10 @@ let make = () => {
           </ToggleButton>
         </ToggleButtonGroup>
       </Box>
-      <Typography gutterBottom=true> "Multiple Selection" </Typography>
+      <Typography gutterBottom=true> {"Multiple Selection"->React.string} </Typography>
       <Typography>
-        "Logically-grouped options, like Bold, Italic, and Underline, allow multiple options to be
-      selected."
+        {"Logically-grouped options, like Bold, Italic, and Underline, allow multiple options to be
+      selected."->React.string}
       </Typography>
     </Grid>
   </Grid>

--- a/examples/src/labExamples/ExamplesLab.res
+++ b/examples/src/labExamples/ExamplesLab.res
@@ -4,7 +4,7 @@ open MaterialUi
 let make = () => <>
   <Grid container=true>
     <Grid item=true md=Grid.Md.\"12">
-      <Typography variant=#h4> "ReScript Material-UI Lab Examples" </Typography>
+      <Typography variant=#h4> {"ReScript Material-UI Lab Examples"->React.string} </Typography>
     </Grid>
   </Grid>
   <br />
@@ -13,7 +13,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Alert" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Alert"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleAlert /> </Grid>
   </Grid>
   <br />
@@ -22,7 +24,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Autocomplete" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Autocomplete"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleAutocomplete /> </Grid>
   </Grid>
   <br />
@@ -31,7 +35,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Pagination" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Pagination"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExamplePagination /> </Grid>
   </Grid>
   <br />
@@ -40,7 +46,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Rating" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Rating"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleRating /> </Grid>
   </Grid>
   <br />
@@ -49,7 +57,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "Skeleton" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"Skeleton"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleSkeleton /> </Grid>
   </Grid>
   <br />
@@ -58,7 +68,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "ToggleButton" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"ToggleButton"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleToggleButton /> </Grid>
   </Grid>
   <br />
@@ -67,7 +79,9 @@ let make = () => <>
   <br />
   <br />
   <Grid container=true alignItems=#center>
-    <Grid item=true md=Grid.Md.\"6"> <Typography variant=#h5> "TreeView" </Typography> </Grid>
+    <Grid item=true md=Grid.Md.\"6">
+      <Typography variant=#h5> {"TreeView"->React.string} </Typography>
+    </Grid>
     <Grid item=true md=Grid.Md.\"6"> <ExampleTreeView /> </Grid>
   </Grid>
   <br />

--- a/ppx-test/src/Index.res
+++ b/ppx-test/src/Index.res
@@ -9,7 +9,7 @@ module App = {
     <NewImplementationTheme />
     <br />
     <br />
-    <center> <Typography variant=#h4> "PPX Result" </Typography> </center>
+    <center> <Typography variant=#h4> {React.string("PPX Result")} </Typography> </center>
     <br />
     <br />
     <NewImplementationPpx />

--- a/public/rescript-material-ui-lab/src/Alert.res
+++ b/public/rescript-material-ui-lab/src/Alert.res
@@ -65,7 +65,7 @@ type variant = [#filled | #outlined | #standard]
 @react.component @module("@material-ui/lab")
 external make: (
   ~action: React.element=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~closeText: string=?,

--- a/public/rescript-material-ui-lab/src/AlertTitle.res
+++ b/public/rescript-material-ui-lab/src/AlertTitle.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui-lab/src/AvatarGroup.res
+++ b/public/rescript-material-ui-lab/src/AvatarGroup.res
@@ -14,7 +14,7 @@ module Spacing = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~max: MaterialUi.Number.t=?,

--- a/public/rescript-material-ui-lab/src/Skeleton.res
+++ b/public/rescript-material-ui-lab/src/Skeleton.res
@@ -65,7 +65,7 @@ module Width = {
 @react.component @module("@material-ui/lab")
 external make: (
   ~animation: Animation.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui-lab/src/SpeedDial.res
+++ b/public/rescript-material-ui-lab/src/SpeedDial.res
@@ -57,7 +57,7 @@ module TransitionDuration = {
 @react.component @module("@material-ui/lab")
 external make: (
   ~ariaLabel: string,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~direction: direction=?,

--- a/public/rescript-material-ui-lab/src/TabContext.res
+++ b/public/rescript-material-ui-lab/src/TabContext.res
@@ -1,6 +1,6 @@
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~value: string,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,

--- a/public/rescript-material-ui-lab/src/TabList.res
+++ b/public/rescript-material-ui-lab/src/TabList.res
@@ -1,6 +1,6 @@
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
   ~key: string=?,

--- a/public/rescript-material-ui-lab/src/TabPanel.res
+++ b/public/rescript-material-ui-lab/src/TabPanel.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~value: string,

--- a/public/rescript-material-ui-lab/src/Timeline.res
+++ b/public/rescript-material-ui-lab/src/Timeline.res
@@ -20,7 +20,7 @@ module Classes = {
 @react.component @module("@material-ui/lab")
 external make: (
   ~align: align=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui-lab/src/TimelineConnector.res
+++ b/public/rescript-material-ui-lab/src/TimelineConnector.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui-lab/src/TimelineContent.res
+++ b/public/rescript-material-ui-lab/src/TimelineContent.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui-lab/src/TimelineDot.res
+++ b/public/rescript-material-ui-lab/src/TimelineDot.res
@@ -27,7 +27,7 @@ type variant = [#default | #outlined]
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui-lab/src/TimelineItem.res
+++ b/public/rescript-material-ui-lab/src/TimelineItem.res
@@ -23,7 +23,7 @@ module Classes = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui-lab/src/TimelineOppositeContent.res
+++ b/public/rescript-material-ui-lab/src/TimelineOppositeContent.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui-lab/src/TimelineSeparator.res
+++ b/public/rescript-material-ui-lab/src/TimelineSeparator.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui-lab/src/ToggleButton.res
+++ b/public/rescript-material-ui-lab/src/ToggleButton.res
@@ -23,7 +23,7 @@ type size = [#small | #medium | #large]
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disabled: bool=?,

--- a/public/rescript-material-ui-lab/src/ToggleButtonGroup.res
+++ b/public/rescript-material-ui-lab/src/ToggleButtonGroup.res
@@ -23,7 +23,7 @@ type size = [#large | #medium | #small]
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~exclusive: bool=?,

--- a/public/rescript-material-ui-lab/src/TreeItem.res
+++ b/public/rescript-material-ui-lab/src/TreeItem.res
@@ -30,7 +30,7 @@ module TransitionComponent = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~collapseIcon: React.element=?,

--- a/public/rescript-material-ui-lab/src/TreeView.res
+++ b/public/rescript-material-ui-lab/src/TreeView.res
@@ -23,7 +23,7 @@ module Selected = {
 
 @react.component @module("@material-ui/lab")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~defaultCollapseIcon: React.element=?,

--- a/public/rescript-material-ui/src/Accordion.res
+++ b/public/rescript-material-ui/src/Accordion.res
@@ -36,7 +36,7 @@ external make: (
   ~component: Component.t=?,
   ~elevation: Number.t=?,
   ~variant: variant=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~defaultExpanded: bool=?,

--- a/public/rescript-material-ui/src/AccordionActions.res
+++ b/public/rescript-material-ui/src/AccordionActions.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disableSpacing: bool=?,

--- a/public/rescript-material-ui/src/AccordionDetails.res
+++ b/public/rescript-material-ui/src/AccordionDetails.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui/src/AccordionSummary.res
+++ b/public/rescript-material-ui/src/AccordionSummary.res
@@ -67,7 +67,7 @@ external make: (
   ~tabIndex: TabIndex.t=?,
   ~\"TouchRippleProps": {..}=?,
   ~\"type": Type.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~expandIcon: React.element=?,

--- a/public/rescript-material-ui/src/AppBar.res
+++ b/public/rescript-material-ui/src/AppBar.res
@@ -48,7 +48,7 @@ external make: (
   ~elevation: Number.t=?,
   ~square: bool=?,
   ~variant: variant=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/Avatar.res
+++ b/public/rescript-material-ui/src/Avatar.res
@@ -35,7 +35,7 @@ type variant = [#circle | #circular | #rounded | #square]
 @react.component @module("@material-ui/core")
 external make: (
   ~alt: string=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/Backdrop.res
+++ b/public/rescript-material-ui/src/Backdrop.res
@@ -39,7 +39,7 @@ external make: (
   ~onExiting: ReactEvent.Synthetic.t => unit=?,
   ~style: ReactDOM.Style.t=?,
   ~timeout: Timeout.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~invisible: bool=?,

--- a/public/rescript-material-ui/src/Badge.res
+++ b/public/rescript-material-ui/src/Badge.res
@@ -79,7 +79,7 @@ type variant = [#dot | #standard]
 external make: (
   ~anchorOrigin: AnchorOrigin.t=?,
   ~badgeContent: React.element=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/BottomNavigation.res
+++ b/public/rescript-material-ui/src/BottomNavigation.res
@@ -12,7 +12,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/BottomNavigationAction.res
+++ b/public/rescript-material-ui/src/BottomNavigationAction.res
@@ -64,7 +64,7 @@ external make: (
   ~tabIndex: TabIndex.t=?,
   ~\"TouchRippleProps": {..}=?,
   ~\"type": Type.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~icon: React.element=?,

--- a/public/rescript-material-ui/src/Box.res
+++ b/public/rescript-material-ui/src/Box.res
@@ -83,7 +83,7 @@ external make: (
   ~className: option<string>=?,
   ~style: option<ReactDOM.Style.t>=?,
   ~clone: option<bool>=?,
-  ~children: option<'children>=?,
+  ~children: option<React.element>=?,
   ~alignContent: option<Value.t>=?,
   ~alignItems: option<Value.t>=?,
   ~alignSelf: option<Value.t>=?,

--- a/public/rescript-material-ui/src/Breadcrumbs.res
+++ b/public/rescript-material-ui/src/Breadcrumbs.res
@@ -19,7 +19,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/Button.res
+++ b/public/rescript-material-ui/src/Button.res
@@ -131,7 +131,7 @@ external make: (
   ~\"TouchRippleProps": {..}=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/ButtonBase.res
+++ b/public/rescript-material-ui/src/ButtonBase.res
@@ -45,7 +45,7 @@ type rel = [
 @react.component @module("@material-ui/core")
 external make: (
   ~centerRipple: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/ButtonGroup.res
+++ b/public/rescript-material-ui/src/ButtonGroup.res
@@ -72,7 +72,7 @@ type variant = [#contained | #outlined | #text]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/Card.res
+++ b/public/rescript-material-ui/src/Card.res
@@ -18,7 +18,7 @@ external make: (
   ~elevation: Number.t=?,
   ~square: bool=?,
   ~variant: variant=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~raised: bool=?,

--- a/public/rescript-material-ui/src/CardActionArea.res
+++ b/public/rescript-material-ui/src/CardActionArea.res
@@ -58,7 +58,7 @@ external make: (
   ~\"type": Type.t=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~focusVisibleClassName: string=?,

--- a/public/rescript-material-ui/src/CardActions.res
+++ b/public/rescript-material-ui/src/CardActions.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disableSpacing: bool=?,

--- a/public/rescript-material-ui/src/CardContent.res
+++ b/public/rescript-material-ui/src/CardContent.res
@@ -12,7 +12,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/CardHeader.res
+++ b/public/rescript-material-ui/src/CardHeader.res
@@ -30,7 +30,7 @@ module Component = {
 external make: (
   ~action: React.element=?,
   ~avatar: React.element=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/CardMedia.res
+++ b/public/rescript-material-ui/src/CardMedia.res
@@ -12,7 +12,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/Checkbox.res
+++ b/public/rescript-material-ui/src/Checkbox.res
@@ -84,7 +84,7 @@ external make: (
   ~\"TouchRippleProps": {..}=?,
   ~\"type": Type.t=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~className: string=?,
   ~disableFocusRipple: bool=?,
   ~edge: Edge.t=?,

--- a/public/rescript-material-ui/src/Chip.res
+++ b/public/rescript-material-ui/src/Chip.res
@@ -83,7 +83,7 @@ type variant = [#default | #outlined]
 @react.component @module("@material-ui/core")
 external make: (
   ~avatar: React.element=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~clickable: bool=?,

--- a/public/rescript-material-ui/src/ClickAwayListener.res
+++ b/public/rescript-material-ui/src/ClickAwayListener.res
@@ -30,7 +30,7 @@ module TouchEvent: {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~disableReactTree: bool=?,
   ~mouseEvent: MouseEvent.t=?,
   ~onClickAway: ReactEvent.Mouse.t => unit,

--- a/public/rescript-material-ui/src/Collapse.res
+++ b/public/rescript-material-ui/src/Collapse.res
@@ -48,7 +48,7 @@ module Timeout = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~collapsedHeight: Number.t=?,

--- a/public/rescript-material-ui/src/Container.res
+++ b/public/rescript-material-ui/src/Container.res
@@ -52,7 +52,7 @@ module MaxWidth: {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/CssBaseline.res
+++ b/public/rescript-material-ui/src/CssBaseline.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,

--- a/public/rescript-material-ui/src/Dialog.res
+++ b/public/rescript-material-ui/src/Dialog.res
@@ -115,7 +115,7 @@ external make: (
   ~\"aria-describedby": string=?,
   ~\"aria-labelledby": string=?,
   ~\"BackdropProps": {..}=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disableBackdropClick: bool=?,

--- a/public/rescript-material-ui/src/DialogActions.res
+++ b/public/rescript-material-ui/src/DialogActions.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disableSpacing: bool=?,

--- a/public/rescript-material-ui/src/DialogContent.res
+++ b/public/rescript-material-ui/src/DialogContent.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~dividers: bool=?,

--- a/public/rescript-material-ui/src/DialogContentText.res
+++ b/public/rescript-material-ui/src/DialogContentText.res
@@ -46,7 +46,7 @@ external make: (
   ~paragraph: bool=?,
   ~variant: variant=?,
   ~variantMapping: {..}=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,

--- a/public/rescript-material-ui/src/DialogTitle.res
+++ b/public/rescript-material-ui/src/DialogTitle.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disableTypography: bool=?,

--- a/public/rescript-material-ui/src/Divider.res
+++ b/public/rescript-material-ui/src/Divider.res
@@ -35,7 +35,7 @@ type variant = [#fullWidth | #inset | #middle]
 @react.component @module("@material-ui/core")
 external make: (
   ~absolute: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/Drawer.res
+++ b/public/rescript-material-ui/src/Drawer.res
@@ -51,7 +51,7 @@ type variant = [#permanent | #persistent | #temporary]
 external make: (
   ~anchor: anchor=?,
   ~\"BackdropProps": {..}=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~elevation: Number.t=?,

--- a/public/rescript-material-ui/src/ExpansionPanel.res
+++ b/public/rescript-material-ui/src/ExpansionPanel.res
@@ -36,7 +36,7 @@ external make: (
   ~component: Component.t=?,
   ~elevation: Number.t=?,
   ~variant: variant=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~defaultExpanded: bool=?,

--- a/public/rescript-material-ui/src/ExpansionPanelActions.res
+++ b/public/rescript-material-ui/src/ExpansionPanelActions.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disableSpacing: bool=?,

--- a/public/rescript-material-ui/src/ExpansionPanelDetails.res
+++ b/public/rescript-material-ui/src/ExpansionPanelDetails.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui/src/ExpansionPanelSummary.res
+++ b/public/rescript-material-ui/src/ExpansionPanelSummary.res
@@ -66,7 +66,7 @@ external make: (
   ~\"type": Type.t=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~expandIcon: React.element=?,

--- a/public/rescript-material-ui/src/Fab.res
+++ b/public/rescript-material-ui/src/Fab.res
@@ -78,7 +78,7 @@ external make: (
   ~\"type": Type.t=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/Fade.res
+++ b/public/rescript-material-ui/src/Fade.res
@@ -12,7 +12,7 @@ module Timeout = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~disableStrictModeCompat: bool=?,
   ~\"in": bool=?,
   ~onEnter: ReactEvent.Synthetic.t => unit=?,

--- a/public/rescript-material-ui/src/FormControl.res
+++ b/public/rescript-material-ui/src/FormControl.res
@@ -32,7 +32,7 @@ type variant = [#filled | #outlined | #standard]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/FormGroup.res
+++ b/public/rescript-material-ui/src/FormGroup.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~row: bool=?,

--- a/public/rescript-material-ui/src/FormHelperText.res
+++ b/public/rescript-material-ui/src/FormHelperText.res
@@ -36,7 +36,7 @@ type variant = [#filled | #outlined | #standard]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/FormLabel.res
+++ b/public/rescript-material-ui/src/FormLabel.res
@@ -34,7 +34,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/Grid.res
+++ b/public/rescript-material-ui/src/Grid.res
@@ -337,7 +337,7 @@ module Xs: {
 external make: (
   ~alignContent: alignContent=?,
   ~alignItems: alignItems=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/GridList.res
+++ b/public/rescript-material-ui/src/GridList.res
@@ -22,7 +22,7 @@ module Component = {
 @react.component @module("@material-ui/core")
 external make: (
   ~cellHeight: CellHeight.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~cols: Number.t=?,

--- a/public/rescript-material-ui/src/GridListTile.res
+++ b/public/rescript-material-ui/src/GridListTile.res
@@ -24,7 +24,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~cols: Number.t=?,

--- a/public/rescript-material-ui/src/Grow.res
+++ b/public/rescript-material-ui/src/Grow.res
@@ -15,7 +15,7 @@ module Timeout = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~disableStrictModeCompat: bool=?,
   ~\"in": bool=?,
   ~onEnter: ReactEvent.Synthetic.t => unit=?,

--- a/public/rescript-material-ui/src/Hidden.res
+++ b/public/rescript-material-ui/src/Hidden.res
@@ -14,7 +14,7 @@ module Only = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~className: string=?,
   ~implementation: implementation=?,
   ~initialWidth: initialWidth=?,

--- a/public/rescript-material-ui/src/Icon.res
+++ b/public/rescript-material-ui/src/Icon.res
@@ -38,7 +38,7 @@ type fontSize = [#default | #inherit | #large | #medium | #small]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/IconButton.res
+++ b/public/rescript-material-ui/src/IconButton.res
@@ -91,7 +91,7 @@ external make: (
   ~\"type": Type.t=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/ImageList.res
+++ b/public/rescript-material-ui/src/ImageList.res
@@ -24,7 +24,7 @@ module RowHeight = {
 @react.component @module("@material-ui/core")
 external make: (
   ~cellHeight: cellHeight=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~cols: Number.t=?,

--- a/public/rescript-material-ui/src/ImageListItem.res
+++ b/public/rescript-material-ui/src/ImageListItem.res
@@ -24,7 +24,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~cols: Number.t=?,

--- a/public/rescript-material-ui/src/InputAdornment.res
+++ b/public/rescript-material-ui/src/InputAdornment.res
@@ -34,7 +34,7 @@ type variant = [#standard | #outlined | #filled]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/InputLabel.res
+++ b/public/rescript-material-ui/src/InputLabel.res
@@ -50,7 +50,7 @@ external make: (
   ~filled: bool=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/Link.res
+++ b/public/rescript-material-ui/src/Link.res
@@ -58,7 +58,7 @@ external make: (
   ~noWrap: bool=?,
   ~paragraph: bool=?,
   ~variantMapping: {..}=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/List.res
+++ b/public/rescript-material-ui/src/List.res
@@ -24,7 +24,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/ListItem.res
+++ b/public/rescript-material-ui/src/ListItem.res
@@ -58,7 +58,7 @@ external make: (
   ~alignItems: alignItems=?,
   ~autoFocus: bool=?,
   ~button: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/ListItemAvatar.res
+++ b/public/rescript-material-ui/src/ListItemAvatar.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui/src/ListItemIcon.res
+++ b/public/rescript-material-ui/src/ListItemIcon.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui/src/ListItemSecondaryAction.res
+++ b/public/rescript-material-ui/src/ListItemSecondaryAction.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui/src/ListItemText.res
+++ b/public/rescript-material-ui/src/ListItemText.res
@@ -21,7 +21,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disableTypography: bool=?,

--- a/public/rescript-material-ui/src/ListSubheader.res
+++ b/public/rescript-material-ui/src/ListSubheader.res
@@ -30,7 +30,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/Menu.res
+++ b/public/rescript-material-ui/src/Menu.res
@@ -103,7 +103,7 @@ external make: (
   ~\"TransitionComponent": TransitionComponent.t=?,
   ~anchorEl: Any.t=?,
   ~autoFocus: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~disableAutoFocusItem: bool=?,
   ~\"MenuListProps": {..}=?,

--- a/public/rescript-material-ui/src/MenuItem.res
+++ b/public/rescript-material-ui/src/MenuItem.res
@@ -50,7 +50,7 @@ external make: (
   ~focusVisibleClassName: string=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/MenuList.res
+++ b/public/rescript-material-ui/src/MenuList.res
@@ -35,7 +35,7 @@ external make: (
   ~style: ReactDOM.Style.t=?,
   ~autoFocus: bool=?,
   ~autoFocusItem: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~className: string=?,
   ~disabledItemsFocusable: bool=?,
   ~disableListWrap: bool=?,

--- a/public/rescript-material-ui/src/MobileStepper.res
+++ b/public/rescript-material-ui/src/MobileStepper.res
@@ -36,7 +36,7 @@ type variant = [#dots | #progress | #text]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~component: Component.t=?,
   ~elevation: Number.t=?,
   ~square: bool=?,

--- a/public/rescript-material-ui/src/Modal.res
+++ b/public/rescript-material-ui/src/Modal.res
@@ -16,7 +16,7 @@ module Container = {
 external make: (
   ~\"BackdropComponent": BackdropComponent.t=?,
   ~\"BackdropProps": {..}=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~closeAfterTransition: bool=?,
   ~container: Container.t=?,
   ~disableAutoFocus: bool=?,

--- a/public/rescript-material-ui/src/NativeSelect.res
+++ b/public/rescript-material-ui/src/NativeSelect.res
@@ -119,7 +119,7 @@ external make: (
   ~rows: Rows.t=?,
   ~startAdornment: React.element=?,
   ~\"type": string=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~\"IconComponent": IconComponent.t=?,
   ~input: React.element=?,

--- a/public/rescript-material-ui/src/NoSsr.res
+++ b/public/rescript-material-ui/src/NoSsr.res
@@ -1,6 +1,6 @@
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~defer: bool=?,
   ~fallback: React.element=?,
   ~id: string=?,

--- a/public/rescript-material-ui/src/Paper.res
+++ b/public/rescript-material-ui/src/Paper.res
@@ -74,7 +74,7 @@ type variant = [#elevation | #outlined]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/Popover.res
+++ b/public/rescript-material-ui/src/Popover.res
@@ -113,7 +113,7 @@ external make: (
   ~anchorOrigin: AnchorOrigin.t=?,
   ~anchorPosition: AnchorPosition.t=?,
   ~anchorReference: anchorReference=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~container: Container.t=?,

--- a/public/rescript-material-ui/src/Popper.res
+++ b/public/rescript-material-ui/src/Popper.res
@@ -35,7 +35,7 @@ type placement = [
 @react.component @module("@material-ui/core")
 external make: (
   ~anchorEl: AnchorEl.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~container: Container.t=?,
   ~disablePortal: bool=?,
   ~keepMounted: bool=?,

--- a/public/rescript-material-ui/src/Portal.res
+++ b/public/rescript-material-ui/src/Portal.res
@@ -7,7 +7,7 @@ module Container = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~container: Container.t=?,
   ~disablePortal: bool=?,
   ~id: string=?,

--- a/public/rescript-material-ui/src/Radio.res
+++ b/public/rescript-material-ui/src/Radio.res
@@ -82,7 +82,7 @@ external make: (
   ~\"TouchRippleProps": {..}=?,
   ~\"type": Type.t=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~className: string=?,
   ~disableFocusRipple: bool=?,
   ~edge: Edge.t=?,

--- a/public/rescript-material-ui/src/RadioGroup.res
+++ b/public/rescript-material-ui/src/RadioGroup.res
@@ -18,7 +18,7 @@ external make: (
   ~row: bool=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~defaultValue: DefaultValue.t=?,
   ~name: string=?,
   ~onChange: ReactEvent.Form.t => unit=?,

--- a/public/rescript-material-ui/src/RootRef.res
+++ b/public/rescript-material-ui/src/RootRef.res
@@ -1,6 +1,6 @@
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
   ~key: string=?,

--- a/public/rescript-material-ui/src/ScopedCssBaseline.res
+++ b/public/rescript-material-ui/src/ScopedCssBaseline.res
@@ -5,7 +5,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~id: string=?,

--- a/public/rescript-material-ui/src/Select.res
+++ b/public/rescript-material-ui/src/Select.res
@@ -126,7 +126,7 @@ external make: (
   ~startAdornment: React.element=?,
   ~\"type": string=?,
   ~autoWidth: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~defaultValue: Any.t=?,
   ~displayEmpty: bool=?,

--- a/public/rescript-material-ui/src/Slide.res
+++ b/public/rescript-material-ui/src/Slide.res
@@ -14,7 +14,7 @@ module Timeout = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~direction: direction=?,
   ~\"in": bool=?,
   ~onEnter: ReactEvent.Synthetic.t => unit=?,

--- a/public/rescript-material-ui/src/Snackbar.res
+++ b/public/rescript-material-ui/src/Snackbar.res
@@ -54,7 +54,7 @@ external make: (
   ~action: React.element=?,
   ~anchorOrigin: AnchorOrigin.t=?,
   ~autoHideDuration: Number.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~\"ClickAwayListenerProps": {..}=?,

--- a/public/rescript-material-ui/src/SnackbarContent.res
+++ b/public/rescript-material-ui/src/SnackbarContent.res
@@ -14,7 +14,7 @@ module Classes = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~component: Component.t=?,
   ~elevation: Number.t=?,
   ~square: bool=?,

--- a/public/rescript-material-ui/src/Step.res
+++ b/public/rescript-material-ui/src/Step.res
@@ -20,7 +20,7 @@ module Classes = {
 @react.component @module("@material-ui/core")
 external make: (
   ~active: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~completed: bool=?,

--- a/public/rescript-material-ui/src/StepButton.res
+++ b/public/rescript-material-ui/src/StepButton.res
@@ -68,7 +68,7 @@ external make: (
   ~style: ReactDOM.Style.t=?,
   ~active: bool=?,
   ~alternativeLabel: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~completed: bool=?,

--- a/public/rescript-material-ui/src/StepContent.res
+++ b/public/rescript-material-ui/src/StepContent.res
@@ -27,7 +27,7 @@ module TransitionDuration = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~\"TransitionComponent": TransitionComponent.t=?,

--- a/public/rescript-material-ui/src/StepLabel.res
+++ b/public/rescript-material-ui/src/StepLabel.res
@@ -38,7 +38,7 @@ module StepIconComponent = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disabled: bool=?,

--- a/public/rescript-material-ui/src/Stepper.res
+++ b/public/rescript-material-ui/src/Stepper.res
@@ -36,7 +36,7 @@ external make: (
   ~style: ReactDOM.Style.t=?,
   ~activeStep: Number.t=?,
   ~alternativeLabel: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~connector: React.element=?,

--- a/public/rescript-material-ui/src/StylesProvider.res
+++ b/public/rescript-material-ui/src/StylesProvider.res
@@ -4,5 +4,5 @@ external make: (
   ~generateClassName: unit => string=?,
   ~injectFirst: bool=?,
   ~jss: {..}=?,
-  ~children: 'children,
+  ~children: React.element,
 ) => React.element = "StylesProvider"

--- a/public/rescript-material-ui/src/SvgIcon.res
+++ b/public/rescript-material-ui/src/SvgIcon.res
@@ -38,7 +38,7 @@ type fontSize = [#default | #inherit | #large | #medium | #small]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/SwipeableDrawer.res
+++ b/public/rescript-material-ui/src/SwipeableDrawer.res
@@ -79,7 +79,7 @@ external make: (
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
   ~anchor: anchor=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~disableBackdropTransition: bool=?,
   ~disableDiscovery: bool=?,
   ~disableSwipeToOpen: bool=?,

--- a/public/rescript-material-ui/src/Switch.res
+++ b/public/rescript-material-ui/src/Switch.res
@@ -96,7 +96,7 @@ external make: (
   ~\"TouchRippleProps": {..}=?,
   ~\"type": Type.t=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~disableFocusRipple: bool=?,
   ~checked: bool=?,
   ~checkedIcon: React.element=?,

--- a/public/rescript-material-ui/src/Tab.res
+++ b/public/rescript-material-ui/src/Tab.res
@@ -75,7 +75,7 @@ external make: (
   ~\"type": Type.t=?,
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disabled: bool=?,

--- a/public/rescript-material-ui/src/TabScrollButton.res
+++ b/public/rescript-material-ui/src/TabScrollButton.res
@@ -9,7 +9,7 @@ type orientation = [#horizontal | #vertical]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~direction: direction,

--- a/public/rescript-material-ui/src/Table.res
+++ b/public/rescript-material-ui/src/Table.res
@@ -16,7 +16,7 @@ type size = [#small | #medium]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/TableBody.res
+++ b/public/rescript-material-ui/src/TableBody.res
@@ -12,7 +12,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/TableCell.res
+++ b/public/rescript-material-ui/src/TableCell.res
@@ -63,7 +63,7 @@ type variant = [#body | #footer | #head]
 @react.component @module("@material-ui/core")
 external make: (
   ~align: align=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/TableContainer.res
+++ b/public/rescript-material-ui/src/TableContainer.res
@@ -12,7 +12,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/TableFooter.res
+++ b/public/rescript-material-ui/src/TableFooter.res
@@ -12,7 +12,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/TableHead.res
+++ b/public/rescript-material-ui/src/TableHead.res
@@ -12,7 +12,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/TablePagination.res
+++ b/public/rescript-material-ui/src/TablePagination.res
@@ -66,7 +66,7 @@ module Component = {
 @react.component @module("@material-ui/core")
 external make: (
   ~align: align=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~padding: padding=?,
   ~scope: string=?,
   ~size: size=?,

--- a/public/rescript-material-ui/src/TableRow.res
+++ b/public/rescript-material-ui/src/TableRow.res
@@ -26,7 +26,7 @@ module Component = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/TableSortLabel.res
+++ b/public/rescript-material-ui/src/TableSortLabel.res
@@ -77,7 +77,7 @@ external make: (
   ~id: string=?,
   ~style: ReactDOM.Style.t=?,
   ~active: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~direction: direction=?,

--- a/public/rescript-material-ui/src/Tabs.res
+++ b/public/rescript-material-ui/src/Tabs.res
@@ -58,7 +58,7 @@ external make: (
   ~\"aria-label": string=?,
   ~\"aria-labelledby": string=?,
   ~centered: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/TextField.res
+++ b/public/rescript-material-ui/src/TextField.res
@@ -67,7 +67,7 @@ external make: (
   ~style: ReactDOM.Style.t=?,
   ~autoComplete: string=?,
   ~autoFocus: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/ThemeProvider.res
+++ b/public/rescript-material-ui/src/ThemeProvider.res
@@ -1,2 +1,2 @@
 @react.component @module("@material-ui/core/styles")
-external make: (~children: 'children, ~theme: Theme.t) => React.element = "ThemeProvider"
+external make: (~children: React.element, ~theme: Theme.t) => React.element = "ThemeProvider"

--- a/public/rescript-material-ui/src/Toolbar.res
+++ b/public/rescript-material-ui/src/Toolbar.res
@@ -26,7 +26,7 @@ type variant = [#regular | #dense]
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~component: Component.t=?,

--- a/public/rescript-material-ui/src/Tooltip.res
+++ b/public/rescript-material-ui/src/Tooltip.res
@@ -61,7 +61,7 @@ module TransitionComponent = {
 @react.component @module("@material-ui/core")
 external make: (
   ~arrow: bool=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~disableFocusListener: bool=?,

--- a/public/rescript-material-ui/src/Typography.res
+++ b/public/rescript-material-ui/src/Typography.res
@@ -101,7 +101,7 @@ type variant = [
 @react.component @module("@material-ui/core")
 external make: (
   ~align: align=?,
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~classes: Classes.t=?,
   ~className: string=?,
   ~color: color=?,

--- a/public/rescript-material-ui/src/Zoom.res
+++ b/public/rescript-material-ui/src/Zoom.res
@@ -12,7 +12,7 @@ module Timeout = {
 
 @react.component @module("@material-ui/core")
 external make: (
-  ~children: 'children=?,
+  ~children: React.element=?,
   ~disableStrictModeCompat: bool=?,
   ~\"in": bool=?,
   ~onEnter: ReactEvent.Synthetic.t => unit=?,

--- a/tools/binding-generator/src/classes/property-parser/_custom.ts
+++ b/tools/binding-generator/src/classes/property-parser/_custom.ts
@@ -71,7 +71,7 @@ const factory = (propertyType: PropType$Custom) => {
     public executeParse() {
       // Custom children
       if (this._property.name === 'children') {
-        this._reasonType = `'children`;
+        this._reasonType = `React.element`;
         return;
       }
 

--- a/tools/binding-generator/src/classes/property-parser/plugins/plugin.children.ts
+++ b/tools/binding-generator/src/classes/property-parser/plugins/plugin.children.ts
@@ -3,7 +3,7 @@ import PluginBase from './base';
 class PluginChildren extends PluginBase {
   public beforeWrite() {
     if (this._parser.property.name === 'children') {
-      this._parser.reasonType = `'children`;
+      this._parser.reasonType = `React.element`;
       this._parser.required = false;
     }
   }

--- a/tools/binding-generator/src/fixed-modules/Box.res
+++ b/tools/binding-generator/src/fixed-modules/Box.res
@@ -83,7 +83,7 @@ external make: (
   ~className: option<string>=?,
   ~style: option<ReactDOM.Style.t>=?,
   ~clone: option<bool>=?,
-  ~children: option<'children>=?,
+  ~children: option<React.element>=?,
   ~alignContent: option<Value.t>=?,
   ~alignItems: option<Value.t>=?,
   ~alignSelf: option<Value.t>=?,

--- a/tools/binding-generator/src/fixed-modules/StylesProvider.res
+++ b/tools/binding-generator/src/fixed-modules/StylesProvider.res
@@ -4,5 +4,5 @@ external make: (
   ~generateClassName: unit => string=?,
   ~injectFirst: bool=?,
   ~jss: {..}=?,
-  ~children: 'children,
+  ~children: React.element,
 ) => React.element = "StylesProvider"

--- a/tools/binding-generator/src/fixed-modules/ThemeProvider.res
+++ b/tools/binding-generator/src/fixed-modules/ThemeProvider.res
@@ -1,2 +1,2 @@
 @react.component @module("@material-ui/core/styles")
-external make: (~children: 'children, ~theme: Theme.t) => React.element = "ThemeProvider"
+external make: (~children: React.element, ~theme: Theme.t) => React.element = "ThemeProvider"


### PR DESCRIPTION
This PR changes the children type from a generic `'children` to `React.element` and thus now uses the same semantics as React(Dom).

Fixes #172 