### PR TITLE
Correct example color source

### DIFF
--- a/documentation/docs/styling/use-styles.md
+++ b/documentation/docs/styling/use-styles.md
@@ -11,7 +11,7 @@ recommended way to replace `withStyles` PPX calls. It utilizes MUI's
 ```rescript
 let useStyles = Mui.Styles.makeStyles({
   "fontSize": ReactDOM.Style.make(~fontSize="30px", ()),
-  "bgColor": ReactDOM.Style.make(~backgroundColor=Mui.Colors.red["300"], ()),
+  "bgColor": ReactDOM.Style.make(~backgroundColor=Mui.Colors.red.c300, ()),
 })
 
 @react.component

--- a/examples/src/examples/ExampleClassOverride.res
+++ b/examples/src/examples/ExampleClassOverride.res
@@ -1,6 +1,6 @@
 let useStyles = Mui.Styles.makeStyles({
   "fontSize": ReactDOM.Style.make(~fontSize="30px", ()),
-  "bgColor": ReactDOM.Style.make(~backgroundColor=Mui.Colors.red["300"], ()),
+  "bgColor": ReactDOM.Style.make(~backgroundColor=Mui.Colors.red.c300, ()),
 })
 
 @react.component


### PR DESCRIPTION
According to https://rescript-material-ui.cca.io/docs/project-structure/module-colors